### PR TITLE
feat: expand genre-specific translation prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Công cụ dịch truyện tranh chuyên nghiệp hỗ trợ đa ngôn ngữ: Ma
 ### 🤖 AI Translation
 - **Gemini 2.0 Flash**: AI dịch thông minh với prompt tối ưu
 - **Context-aware**: Hiểu ngữ cảnh manga/manhua/manhwa
+- **Genre prompts**: Prompt chuyên dụng cho từng thể loại (Hành động, Tình cảm, Hài hước, Kinh dị, Kiếm hiệp, Tiên hiệp, Game giả tưởng)
 - **Cultural adaptation**: Dịch phù hợp văn hóa Việt Nam
 - **Onomatopoeia handling**: Xử lý hiệu ứng âm thanh chuyên nghiệp
 
@@ -62,8 +63,9 @@ python app.py
    - 🔄 **Bing, Sogou, Helsinki-NLP** - Các lựa chọn khác
 3. **Chọn font** phù hợp với style truyện
 4. **Chọn ngôn ngữ nguồn** hoặc để "Tự động"
-5. **Nhập Gemini API key** (cho dịch AI - tùy chọn)
-6. **Submit và thưởng thức kết quả!**
+5. **Chọn thể loại truyện** (Hành động, Tình cảm, Hài hước, Kinh dị, Kiếm hiệp, Tiên hiệp, Game giả tưởng) hoặc để "Tự động"
+6. **Nhập Gemini API key** (cho dịch AI - tùy chọn)
+7. **Submit và thưởng thức kết quả!**
 
 ## 🔧 Cấu hình
 

--- a/app.py
+++ b/app.py
@@ -51,7 +51,7 @@ DESCRIPTION = """
 """
 
 
-def predict(img, translation_method, font_path, source_language="auto", gemini_api_key=None):
+def predict(img, translation_method, font_path, source_language="auto", genre="auto", gemini_api_key=None):
     """
     Main prediction function for manga translation
     
@@ -60,6 +60,7 @@ def predict(img, translation_method, font_path, source_language="auto", gemini_a
         translation_method: Translation service to use
         font_path: Path to font file for text rendering
         source_language: Source language code or 'auto' for auto-detection
+        genre: Comic genre for specialized prompts
         gemini_api_key: Optional Gemini API key
     
     Returns:
@@ -78,6 +79,7 @@ def predict(img, translation_method, font_path, source_language="auto", gemini_a
     # Debug logging
     print(f"Using translation method: {translation_method}")
     print(f"Source language: {source_language}")
+    print(f"Genre: {genre}")
     print(f"API key available: {'Yes' if gemini_api_key else 'No'}")
     if gemini_api_key:
         print(f"API key preview: {gemini_api_key[:10]}...")
@@ -126,7 +128,8 @@ def predict(img, translation_method, font_path, source_language="auto", gemini_a
         if text:  # Only translate if text exists
             text_translated = manga_translator.translate(text,
                                                          method=translation_method,
-                                                         source_lang=source_language)
+                                                         source_lang=source_language,
+                                                         genre=genre)
             print(f"🌏 Translated: '{text_translated}'")
         else:
             text_translated = ""
@@ -171,9 +174,21 @@ demo = gr.Interface(
                     label="Ngôn ngữ gốc",
                     value="auto"),
         
+        # Genre dropdown
+        gr.Dropdown([("Tự động", "auto"),
+                     ("Hành động", "action"),
+                     ("Tình cảm", "romance"),
+                     ("Hài hước", "comedy"),
+                     ("Kinh dị", "horror"),
+                     ("Kiếm hiệp", "wuxia"),
+                     ("Tiên hiệp", "xianxia"),
+                     ("Game giả tưởng", "fantasy_game")],
+                    label="Thể loại truyện",
+                    value="auto"),
+
         # API key input
-        gr.Textbox(label="Gemini API Key (Tùy chọn)", 
-                   type="password", 
+        gr.Textbox(label="Gemini API Key (Tùy chọn)",
+                   type="password",
                    placeholder="Nhập API key để dịch AI thông minh",
                    value=os.getenv("GEMINI_API_KEY", ""))
     ],


### PR DESCRIPTION
## Summary
- support additional comic genres like Kiếm hiệp, Tiên hiệp, and Game giả tưởng
- wire new genre choices into the Gradio client for user selection
- document the expanded genre list in the README

## Testing
- `python -m py_compile translator.py app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689acc69ca2c8323879f10548c034bed